### PR TITLE
Add JWT refresh secret configuration

### DIFF
--- a/strings.tf
+++ b/strings.tf
@@ -13,6 +13,13 @@ resource "random_string" "jwt_secret" {
   special = false
 }
 
+resource "random_string" "jwt_refresh_secret" {
+  length  = 64
+  lower   = true
+  upper   = false
+  special = false
+}
+
 resource "random_string" "creds_key" {
   length  = 64
   lower   = true

--- a/webapps.tf
+++ b/webapps.tf
@@ -72,6 +72,7 @@ resource "azurerm_linux_web_app" "librechat" {
     CREDS_IV  = random_string.creds_iv.result
 
     JWT_SECRET    = random_string.jwt_secret.result
+    JWT_REFRESH_SECRET = random_string.jwt_refresh_secret.result
     DOMAIN_SERVER = "http://localhost:3080"
     DOMAIN_CLIENT = "http://localhost:3080"
 


### PR DESCRIPTION
This PR introduces the addition of the JWT_REFRESH_SECRET. This update is necessary due to the recent changes in our environment configuration which now require JWT_REFRESH_SECRET to be set.

This change was prompted by the breaking changes introduced in version 0.5.9 as detailed in the [following documentation](https://github.com/danny-avila/LibreChat/blob/main/docs/general_info/breaking_changes.md#v059).