### PR TITLE
Modify Terraform environment variable configuration for Azure OpenAI in Librechat

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "location" {
   description = "The location where all resources will be deployed"
-  default     = "westeurope"
+  default     = "australiaeast"
 }
 
 variable "app_title" {
@@ -65,22 +65,54 @@ variable "deployments" {
     scale_type = string
   }))
   default = {
-    "chat_model" = {
+    "gpt-35-turbo" = {
       name = "gpt-35-turbo"
       rai_policy_name = "Microsoft.Default"
       model_name = "gpt-35-turbo"
       model_format = "OpenAI"
-      model_version = "0301"
+      model_version = "0613"
       scale_type = "Standard"
     },
-    "embedding_model" = {
+    "gpt-35-turbo-1106" = {
+      name = "gpt-35-turbo-1106"
+      rai_policy_name = "Microsoft.Default"
+      model_name = "gpt-35-turbo"
+      model_format = "OpenAI"
+      model_version = "1106"
+      scale_type = "Standard"
+    },
+    "gpt-4" = {
+      name = "gpt-4"
+      rai_policy_name = "Microsoft.Default"
+      model_name = "gpt-4"
+      model_format = "OpenAI"
+      model_version = "0613"
+      scale_type = "Standard"
+    },
+    "gpt-4-1106-preview" = {
+      name = "gpt-4-1106-preview"
+      rai_policy_name = "Microsoft.Default"
+      model_name = "gpt-4"
+      model_format = "OpenAI"
+      model_version = "1106-Preview"
+      scale_type = "Standard"
+    },
+    "gpt-4-vision-preview" = {
+      name = "gpt-4-vision-preview"
+      rai_policy_name = "Microsoft.Default"
+      model_name = "gpt-4"
+      model_format = "OpenAI"
+      model_version = "vision-preview"
+      scale_type = "Standard"
+    },
+    "text-embedding-ada-002" = {
       name = "text-embedding-ada-002"
       rai_policy_name = "Microsoft.Default"
-      model_format = "OpenAI"
       model_name = "text-embedding-ada-002"
+      model_format = "OpenAI"
       model_version = "2"
       scale_type = "Standard"
-    }
+    },
   }
 }
 

--- a/webapps.tf
+++ b/webapps.tf
@@ -46,11 +46,17 @@ resource "azurerm_linux_web_app" "librechat" {
     APP_TITLE = var.app_title
 
     AZURE_API_KEY                                = module.openai.openai_primary_key
+    AZURE_OPENAI_MODELS                          = "gpt-4-1106-preview,gpt-4,gpt-3.5-turbo,gpt-3.5-turbo-1106,gpt-4-vision-preview"
+    AZURE_OPENAI_DEFAULT_MODEL                   = "gpt-3.5-turbo"
+    # PLUGINS_USE_AZURE                            = true
+
+    AZURE_USE_MODEL_AS_DEPLOYMENT_NAME           = true
+
     AZURE_OPENAI_API_INSTANCE_NAME               = split("//", split(".", module.openai.openai_endpoint)[0])[1]
-    AZURE_OPENAI_API_DEPLOYMENT_NAME             = var.azure_openai_api_deployment_name != "" ? var.azure_openai_api_deployment_name : (contains(keys(var.deployments), "chat_model") ? var.deployments.chat_model.name : "")
+    # AZURE_OPENAI_API_DEPLOYMENT_NAME             =
     AZURE_OPENAI_API_VERSION                     = var.azure_openai_api_version
-    AZURE_OPENAI_API_COMPLETIONS_DEPLOYMENT_NAME = var.azure_openai_api_completions_deployment_name != "" ? var.azure_openai_api_completions_deployment_name : (contains(keys(var.deployments), "chat_model") ? var.deployments.chat_model.name : "")
-    AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME  = var.azure_openai_api_embeddings_deployment_name != "" ? var.azure_openai_api_embeddings_deployment_name : (contains(keys(var.deployments), "embedding_model") ? var.deployments.embedding_model.name : "")
+    # AZURE_OPENAI_API_COMPLETIONS_DEPLOYMENT_NAME =
+    # AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME  =
 
     CHATGPT_TOKEN  = var.chatgpt_token
     CHATGPT_MODELS = "text-davinci-002-render-sha,gpt-4"


### PR DESCRIPTION
## Summary
In response to the updated setup instructions for Librechat's Azure OpenAI setup process, I have made the following changes to the Terraform configuration.

## Changes Made
1. Updated `variables.tf`:
- Changed the region to "Australia East" to use the [preview models](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models#gpt-4-and-gpt-4-turbo-preview-model-availability).
- Modified the configuration to deploy all Azure OpenAI models.

2. Updated `webapps.tf`:
- Set the environment variables based on the latest documentation ([Azure OpenAI Setup Documentation](https://docs.librechat.ai/install/ai_setup.html#azure-openai)).

## Testing and Verification
- Executed `terraform plan` and `terraform apply` with the updated Terraform configuration to ensure that resources are provisioned correctly.
- Verified the setup by performing the actual setup on an Azure environment and ensuring the smooth functioning of Librechat.

## Reference

For reference, please check the specified section of the code [here](https://github.com/danny-avila/LibreChat/blob/5b283622826ca12599ed7690ec1b53223d5cec70/.env.example#L52-L68).
