### PR TITLE
Update Azure OpenAI API version to "2024-02-01"

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -144,7 +144,7 @@ variable "azure_openai_api_completions_deployment_name" {
 
 variable "azure_openai_api_version" {
   description = "The version of your Azure OpenAI API"
-  default     = "2023-05-15"
+  default     = "2024-02-01"
 }
 
 variable "azure_openai_api_embeddings_deployment_name" {


### PR DESCRIPTION
# Summary

I have updated the Azure OpenAI API version being used in our project. The version has been changed from "2023-05-15" to "2024-02-01".

# Testing and Verification

To verify the changes made, I executed the `terraform apply` command with the updated Terraform configuration. The results indicated that the prospective resources have been provisioned correctly and as expected. Furthermore, I set up a real Azure environment using these configurations and was able to confirm that Librechat operates smoothly.

# Reference

https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation 
